### PR TITLE
Add ability to dial API via unix socket

### DIFF
--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -19,6 +19,7 @@ hosts:
   github.com:
     user: monalisa
     oauth_token: OTOKEN
+    http_unix_socket: /foo/socket
 `, "")()
 	config, err := parseConfig("config.yml")
 	assert.NoError(t, err)
@@ -28,6 +29,9 @@ hosts:
 	token, err := config.Get("github.com", "oauth_token")
 	assert.NoError(t, err)
 	assert.Equal(t, "OTOKEN", token)
+	socket, err := config.Get("github.com", "http_unix_socket")
+	assert.NoError(t, err)
+	assert.Equal(t, "/foo/socket", socket)
 }
 
 func Test_parseConfig_multipleHosts(t *testing.T) {
@@ -36,9 +40,11 @@ hosts:
   example.com:
     user: wronguser
     oauth_token: NOTTHIS
+    http_unix_socket: /not/this/socket
   github.com:
     user: monalisa
     oauth_token: OTOKEN
+    http_unix_socket: /foo/socket
 `, "")()
 	config, err := parseConfig("config.yml")
 	assert.NoError(t, err)
@@ -48,6 +54,9 @@ hosts:
 	token, err := config.Get("github.com", "oauth_token")
 	assert.NoError(t, err)
 	assert.Equal(t, "OTOKEN", token)
+	socket, err := config.Get("github.com", "http_unix_socket")
+	assert.NoError(t, err)
+	assert.Equal(t, "/foo/socket", socket)
 }
 
 func Test_parseConfig_hostsFile(t *testing.T) {

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -50,6 +50,11 @@ var configOptions = []ConfigOption{
 		Description:  "the terminal pager program to send standard output to",
 		DefaultValue: "",
 	},
+	{
+		Key:          "http_unix_socket",
+		Description:  "the path to a unix socket through which to make HTTP connection",
+		DefaultValue: "",
+	},
 }
 
 func ConfigOptions() []ConfigOption {
@@ -178,6 +183,15 @@ func NewBlankRoot() *yaml.Node {
 								Value: "pr checkout",
 							},
 						},
+					},
+					{
+						HeadComment: "The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.",
+						Kind:        yaml.ScalarNode,
+						Value:       "http_unix_socket",
+					},
+					{
+						Kind:  yaml.ScalarNode,
+						Value: "",
 					},
 				},
 			},

--- a/internal/config/config_type_test.go
+++ b/internal/config/config_type_test.go
@@ -18,6 +18,7 @@ func Test_fileConfig_Set(t *testing.T) {
 	assert.NoError(t, c.Set("github.com", "git_protocol", "ssh"))
 	assert.NoError(t, c.Set("example.com", "editor", "vim"))
 	assert.NoError(t, c.Set("github.com", "user", "hubot"))
+	assert.NoError(t, c.Set("example.com", "http_unix_socket", "/foo/socket"))
 	assert.NoError(t, c.Write())
 
 	assert.Contains(t, mainBuf.String(), "editor: nano")
@@ -27,6 +28,7 @@ func Test_fileConfig_Set(t *testing.T) {
     user: hubot
 example.com:
     editor: vim
+    http_unix_socket: /foo/socket
 `, hostsBuf.String())
 }
 
@@ -50,6 +52,8 @@ func Test_defaultConfig(t *testing.T) {
 		# Aliases allow you to create nicknames for gh commands
 		aliases:
 		    co: pr checkout
+		# The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
+		http_unix_socket:
 	`)
 	assert.Equal(t, expected, mainBuf.String())
 	assert.Equal(t, "", hostsBuf.String())
@@ -81,6 +85,9 @@ func Test_ValidateValue(t *testing.T) {
 
 	err = ValidateValue("got", "123")
 	assert.NoError(t, err)
+
+	err = ValidateValue("http_unix_socket", "really_anything/is/allowed/and/net.Dial\\(...\\)/will/ultimately/validate")
+	assert.NoError(t, err)
 }
 
 func Test_ValidateKey(t *testing.T) {
@@ -97,5 +104,8 @@ func Test_ValidateKey(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = ValidateKey("pager")
+	assert.NoError(t, err)
+
+	err = ValidateKey("http_unix_socket")
 	assert.NoError(t, err)
 }

--- a/internal/httpunix/transport.go
+++ b/internal/httpunix/transport.go
@@ -1,0 +1,21 @@
+// package httpunix provides an http.RoundTripper which dials a server via a unix socket.
+package httpunix
+
+import (
+	"net"
+	"net/http"
+)
+
+// NewRoundTripper returns an http.RoundTripper which sends requests via a unix
+// socket at socketPath.
+func NewRoundTripper(socketPath string) http.RoundTripper {
+	dial := func(network, addr string) (net.Conn, error) {
+		return net.Dial("unix", socketPath)
+	}
+
+	return &http.Transport{
+		Dial:              dial,
+		DialTLS:           dial,
+		DisableKeepAlives: true,
+	}
+}

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -52,7 +52,7 @@ func New(appVersion string) *cmdutil.Factory {
 				return nil, err
 			}
 
-			return NewHTTPClient(io, cfg, appVersion, true), nil
+			return NewHTTPClient(io, cfg, appVersion, true)
 		},
 		BaseRepo: func() (ghrepo.Interface, error) {
 			remotes, err := remotesFunc()

--- a/pkg/cmd/factory/http.go
+++ b/pkg/cmd/factory/http.go
@@ -54,7 +54,7 @@ var timezoneNames = map[int]string{
 }
 
 // generic authenticated HTTP client for commands
-func NewHTTPClient(io *iostreams.IOStreams, cfg config.Config, appVersion string, setAccept bool) *http.Client {
+func NewHTTPClient(io *iostreams.IOStreams, cfg config.Config, appVersion string, setAccept bool) (*http.Client, error) {
 	var opts []api.ClientOption
 	if verbose := os.Getenv("DEBUG"); verbose != "" {
 		logTraffic := strings.Contains(verbose, "api")
@@ -98,5 +98,5 @@ func NewHTTPClient(io *iostreams.IOStreams, cfg config.Config, appVersion string
 		)
 	}
 
-	return api.NewHTTPClient(opts...)
+	return api.NewHTTPClient(opts...), nil
 }

--- a/pkg/cmd/factory/http.go
+++ b/pkg/cmd/factory/http.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/config"
 	"github.com/cli/cli/internal/ghinstance"
+	"github.com/cli/cli/internal/httpunix"
 	"github.com/cli/cli/pkg/iostreams"
 )
 
@@ -56,6 +57,29 @@ var timezoneNames = map[int]string{
 // generic authenticated HTTP client for commands
 func NewHTTPClient(io *iostreams.IOStreams, cfg config.Config, appVersion string, setAccept bool) (*http.Client, error) {
 	var opts []api.ClientOption
+
+	// We need to check and potentially add the unix socket roundtripper option
+	// before adding any other options, since if we are going to use the unix
+	// socket transport, it needs to form the base of the transport chain
+	// represented by invocations of opts...
+	//
+	// Another approach might be to change the signature of api.NewHTTPClient to
+	// take an explicit base http.RoundTripper as its first parameter (it
+	// currently defaults internally to http.DefaultTransport), or add another
+	// variant like api.NewHTTPClientWithBaseRoundTripper. But, the only caller
+	// which would use that non-default behavior is right here, and it doesn't
+	// seem worth the cognitive overhead everywhere else just to serve this one
+	// use case.
+	unixSocket, err := cfg.Get("", "http_unix_socket")
+	if err != nil {
+		return nil, err
+	}
+	if unixSocket != "" {
+		opts = append(opts, api.ClientOption(func(http.RoundTripper) http.RoundTripper {
+			return httpunix.NewRoundTripper(unixSocket)
+		}))
+	}
+
 	if verbose := os.Getenv("DEBUG"); verbose != "" {
 		logTraffic := strings.Contains(verbose, "api")
 		opts = append(opts, api.VerboseLog(io.ErrOut, logTraffic, io.IsStderrTTY()))

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -123,7 +123,7 @@ func bareHTTPClient(f *cmdutil.Factory, version string) func() (*http.Client, er
 		if err != nil {
 			return nil, err
 		}
-		return factory.NewHTTPClient(f.IOStreams, cfg, version, false), nil
+		return factory.NewHTTPClient(f.IOStreams, cfg, version, false)
 	}
 }
 


### PR DESCRIPTION
This change adds the ability to route HTTP traffic over a unix domain socket. It does so by reading an optional configuration value, `http_unix_socket`, containing the path of the socket.

The code here is broken into some smaller changes to (hopefully) aid in its review. We first refactor `NewHTTPClient` to allow for error returns, and add the new `http.RoundTripper` implementation returned by `httpunix.NewRoundTripper`. Next we add configuration support for the new value `http_unix_socket`. Finally, we read and use this configuration value if present.

In addition to the unit tests around configuration, this change has been used by me internally in my normal work over the last few weeks.

Fixes #3268
